### PR TITLE
Add documentation, CSS Modules, tests, Google auth, and CI

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
     "ghcr.io/devcontainers/features/github-cli:1": {}
   },
 
-  "postCreateCommand": "npm install --prefix frontend && npm install --prefix worker && npm --prefix frontend run playwright:install",
+  "postCreateCommand": "npm install --prefix frontend && npm install --prefix worker && npm --prefix frontend run playwright:install && git config core.hooksPath .githooks",
 
   "forwardPorts": [5173, 8787],
   "portsAttributes": {

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,52 @@
+#!/bin/sh
+# pre-push hook — push 前にすべてのテストを実行する
+# git config core.hooksPath .githooks で有効化
+
+set -e
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+RESET='\033[0m'
+
+ROOT="$(git rev-parse --show-toplevel)"
+
+pass() { printf "${GREEN}✓ $1${RESET}\n"; }
+fail() { printf "${RED}✗ $1${RESET}\n"; }
+step() { printf "\n${CYAN}▶ $1${RESET}\n"; }
+
+printf "${YELLOW}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}\n"
+printf "${YELLOW}  Pre-push: running all tests...${RESET}\n"
+printf "${YELLOW}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}\n"
+
+# ── 1. Worker ユニットテスト ──────────────────────────────
+step "Worker unit tests (Vitest)"
+if npm --prefix "$ROOT/worker" run test:run --silent; then
+  pass "Worker unit tests"
+else
+  fail "Worker unit tests failed"
+  exit 1
+fi
+
+# ── 2. Frontend ユニットテスト ────────────────────────────
+step "Frontend unit tests (Vitest)"
+if npm --prefix "$ROOT/frontend" run test:run --silent; then
+  pass "Frontend unit tests"
+else
+  fail "Frontend unit tests failed"
+  exit 1
+fi
+
+# ── 3. Frontend E2E テスト ────────────────────────────────
+step "Frontend E2E tests (Playwright)"
+if npm --prefix "$ROOT/frontend" run test:e2e -- --reporter=line; then
+  pass "E2E tests"
+else
+  fail "E2E tests failed"
+  exit 1
+fi
+
+printf "\n${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}\n"
+printf "${GREEN}  All tests passed! Pushing...${RESET}\n"
+printf "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}\n\n"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,57 @@
+name: Test
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  unit-tests:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: |
+            frontend/package-lock.json
+            worker/package-lock.json
+
+      - name: Install dependencies
+        run: |
+          npm ci --prefix frontend
+          npm ci --prefix worker
+
+      - name: Worker unit tests
+        run: npm --prefix worker run test:run
+
+      - name: Frontend unit tests
+        run: npm --prefix frontend run test:run
+
+  e2e-tests:
+    name: E2E Tests (Playwright)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci --prefix frontend
+
+      - name: Install Playwright browsers
+        run: npm --prefix frontend run playwright:install
+
+      - name: Run E2E tests
+        run: npm --prefix frontend run test:e2e
+        env:
+          CI: true
+          VITE_SKIP_AUTH: "true"

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -24,5 +24,6 @@ export default defineConfig({
     url: "http://localhost:5173",
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,
+    env: { VITE_SKIP_AUTH: "true" },
   },
 });

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,12 +1,18 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { todayStr, tomorrowStr, directionConfig } from "./utils.js";
+import { fetchMe, saveToken, clearToken } from "./api.ts";
 import TodoCard from "./components/TodoCard.jsx";
 import ActionButton from "./components/ActionButton.jsx";
 import BulkAddModal from "./components/BulkAddModal.jsx";
 import EditModal from "./components/EditModal.jsx";
 import DeleteConfirmModal from "./components/DeleteConfirmModal.jsx";
 import ListView from "./components/ListView.jsx";
+import LoginScreen from "./components/LoginScreen.jsx";
 import styles from "./App.module.css";
+
+// VITE_API_URL が設定されていて VITE_SKIP_AUTH が未設定のとき認証が必要
+const AUTH_REQUIRED =
+  !!import.meta.env.VITE_API_URL && import.meta.env.VITE_SKIP_AUTH !== "true";
 
 const INITIAL_TODOS = [
   { id: 1, title: "デザインレビュー", memo: "Figmaのモックアップを確認してフィードバックを送る", priority: 0, dueDate: todayStr(), snoozedUntil: null },
@@ -17,6 +23,9 @@ const INITIAL_TODOS = [
 ];
 
 export default function App() {
+  const [user, setUser] = useState(null);
+  const [authLoading, setAuthLoading] = useState(AUTH_REQUIRED);
+
   const [todos, setTodos] = useState(INITIAL_TODOS);
   const [done, setDone] = useState([]);
   const [trash, setTrash] = useState([]);
@@ -30,6 +39,22 @@ export default function App() {
   const [screen, setScreen] = useState("main");
   const [deleteTarget, setDeleteTarget] = useState(null);
   const [editingTodo, setEditingTodo] = useState(null);
+
+  useEffect(() => {
+    if (!AUTH_REQUIRED) return;
+    // OAuth コールバック後の ?token= パラメータを処理
+    const params = new URLSearchParams(window.location.search);
+    const token = params.get("token");
+    if (token) {
+      saveToken(token);
+      window.history.replaceState({}, "", window.location.pathname);
+    }
+    // トークンを検証してユーザー情報を取得
+    fetchMe().then((u) => {
+      setUser(u);
+      setAuthLoading(false);
+    });
+  }, []);
 
   const visibleTodos = todos.filter(t => !t.snoozedUntil || t.snoozedUntil <= todayStr());
   const snoozedCount = todos.filter(t => t.snoozedUntil && t.snoozedUntil > todayStr()).length;
@@ -139,6 +164,16 @@ export default function App() {
     else { setTrash(tr => tr.filter(x => x.id !== id)); showToast("完全に削除しました", "#f87171"); }
   }
 
+  // 認証チェック中
+  if (authLoading) {
+    return <div className={styles.authLoading} />;
+  }
+
+  // 未ログイン
+  if (AUTH_REQUIRED && !user) {
+    return <LoginScreen />;
+  }
+
   const Toast = toast && (
     <div className={styles.toast} style={{ "--toast-color": toast.color }}>
       {toast.msg}
@@ -180,6 +215,15 @@ export default function App() {
           <h1 className={styles.headerTitle}>Todo</h1>
         </div>
         <div className={styles.headerActions}>
+          {user && (
+            <button
+              className={styles.btnUser}
+              onClick={() => { clearToken(); setUser(null); }}
+              title={`${user.name} (${user.email}) — クリックでログアウト`}
+            >
+              <img src={user.picture} alt={user.name} className={styles.userAvatar} referrerPolicy="no-referrer" />
+            </button>
+          )}
           <button className={styles.btnIcon} onClick={() => setScreen("list")}>
             ☰
             {notifCount > 0 && (

--- a/frontend/src/App.module.css
+++ b/frontend/src/App.module.css
@@ -424,3 +424,33 @@
 .btnSubmit:hover {
   opacity: 0.9;
 }
+
+/* ── 認証 ── */
+.authLoading {
+  width: 100%;
+  min-height: 100dvh;
+  background: #1c1c2e;
+}
+
+.btnUser {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  border-radius: 50%;
+  line-height: 0;
+  opacity: 0.9;
+  transition: opacity 0.2s;
+}
+
+.btnUser:hover {
+  opacity: 1;
+}
+
+.userAvatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 2px solid rgba(255, 255, 255, 0.2);
+}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -13,20 +13,63 @@ export type Todo = {
   snoozedUntil: string | null;
 };
 
+export type User = {
+  email: string;
+  name: string;
+  picture: string;
+};
+
+// ── 認証トークン管理 ──────────────────────────────────────
+
+export function getToken(): string | null {
+  return localStorage.getItem("auth_token");
+}
+
+export function saveToken(token: string): void {
+  localStorage.setItem("auth_token", token);
+}
+
+export function clearToken(): void {
+  localStorage.removeItem("auth_token");
+}
+
+function authHeaders(): Record<string, string> {
+  const token = getToken();
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+// ── fetch ラッパー ────────────────────────────────────────
+
 async function req<T>(path: string, options: RequestInit = {}): Promise<T> {
   const res = await fetch(`${BASE}${path}`, {
-    headers: { "Content-Type": "application/json" },
     ...options,
+    headers: {
+      "Content-Type": "application/json",
+      ...authHeaders(),
+      ...(options.headers as Record<string, string> ?? {}),
+    },
   });
   if (!res.ok) throw new Error(`API error: ${res.status}`);
   return res.json();
 }
 
-// タスク一覧取得
+// ── 認証 API ─────────────────────────────────────────────
+
+export async function fetchMe(): Promise<User | null> {
+  if (!getToken()) return null;
+  try {
+    const data = await req<{ user: User | null }>("/auth/me");
+    return data.user;
+  } catch {
+    return null;
+  }
+}
+
+// ── タスク API ────────────────────────────────────────────
+
 export const fetchTodos = (): Promise<Todo[]> =>
   req("/api/todos");
 
-// タスク作成
 export const createTodo = (data: {
   title: string;
   memo?: string;
@@ -35,24 +78,20 @@ export const createTodo = (data: {
 }): Promise<Todo> =>
   req("/api/todos", { method: "POST", body: JSON.stringify(data) });
 
-// 一括タスク作成
 export const bulkCreateTodos = (titles: string[]): Promise<Todo[]> =>
   req("/api/todos/bulk", { method: "POST", body: JSON.stringify({ titles }) });
 
-// タスク更新（メモ・期限・優先度・スヌーズ）
 export const updateTodo = (
   id: string,
   data: Partial<Pick<Todo, "memo" | "dueDate" | "priority" | "snoozedUntil">>
 ): Promise<Todo> =>
   req(`/api/todos/${id}`, { method: "PATCH", body: JSON.stringify(data) });
 
-// 完了・未完了切り替え
 export const completeTodo = (id: string, completed: boolean): Promise<Todo> =>
   req(`/api/todos/${id}/complete`, {
     method: "PATCH",
     body: JSON.stringify({ completed }),
   });
 
-// タスク削除（ゴミ箱へ = Asana 上は delete）
 export const deleteTodo = (id: string): Promise<{ ok: boolean }> =>
   req(`/api/todos/${id}`, { method: "DELETE" });

--- a/frontend/src/components/LoginScreen.jsx
+++ b/frontend/src/components/LoginScreen.jsx
@@ -1,0 +1,54 @@
+import styles from "./LoginScreen.module.css";
+
+const API_URL = import.meta.env.VITE_API_URL ?? "";
+
+export default function LoginScreen() {
+  const params = new URLSearchParams(window.location.search);
+  const authError = params.get("auth_error");
+
+  const errorMessages = {
+    cancelled: "ログインがキャンセルされました",
+    unauthorized: "このアカウントはアクセスが許可されていません",
+    unverified: "メールアドレスが確認されていません",
+    token_exchange: "認証に失敗しました。もう一度お試しください",
+  };
+
+  return (
+    <div className={styles.screen}>
+      <div className={styles.bgGlow} />
+      <div className={styles.card}>
+        <div className={styles.appLabel}>Swipe</div>
+        <h1 className={styles.appTitle}>Todo</h1>
+        <p className={styles.tagline}>タスクをスワイプで管理</p>
+
+        {authError && (
+          <div className={styles.errorBanner}>
+            {errorMessages[authError] ?? "ログインエラーが発生しました"}
+          </div>
+        )}
+
+        <a className={styles.googleBtn} href={`${API_URL}/auth/google`}>
+          <svg className={styles.googleIcon} viewBox="0 0 24 24" aria-hidden="true">
+            <path
+              fill="#4285F4"
+              d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+            />
+            <path
+              fill="#34A853"
+              d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+            />
+            <path
+              fill="#FBBC05"
+              d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l3.66-2.84z"
+            />
+            <path
+              fill="#EA4335"
+              d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+            />
+          </svg>
+          Google でサインイン
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/LoginScreen.module.css
+++ b/frontend/src/components/LoginScreen.module.css
@@ -1,0 +1,109 @@
+.screen {
+  min-height: 100dvh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #1c1c2e;
+  position: relative;
+  overflow: hidden;
+  padding: 24px;
+}
+
+.bgGlow {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(ellipse 60% 40% at 50% 20%, rgba(124, 58, 237, 0.18) 0%, transparent 70%),
+    radial-gradient(ellipse 40% 30% at 80% 80%, rgba(99, 102, 241, 0.1) 0%, transparent 60%);
+  pointer-events: none;
+}
+
+.card {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  max-width: 360px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 28px;
+  padding: 48px 36px 40px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.4);
+  backdrop-filter: blur(12px);
+}
+
+.appLabel {
+  font-family: "Syne", sans-serif;
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.4);
+}
+
+.appTitle {
+  font-family: "Syne", sans-serif;
+  font-size: 52px;
+  font-weight: 800;
+  color: #fff;
+  margin: 0;
+  line-height: 1;
+  background: linear-gradient(135deg, #fff 30%, rgba(167, 139, 250, 0.9));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.tagline {
+  font-family: "DM Sans", sans-serif;
+  font-size: 14px;
+  color: rgba(255, 255, 255, 0.4);
+  margin: 4px 0 24px;
+}
+
+.errorBanner {
+  width: 100%;
+  background: rgba(248, 113, 113, 0.12);
+  border: 1px solid rgba(248, 113, 113, 0.3);
+  border-radius: 12px;
+  padding: 12px 16px;
+  font-family: "DM Sans", sans-serif;
+  font-size: 13px;
+  color: #fca5a5;
+  text-align: center;
+  margin-bottom: 8px;
+}
+
+.googleBtn {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  padding: 14px 20px;
+  background: #fff;
+  border-radius: 14px;
+  color: #1f1f1f;
+  font-family: "DM Sans", sans-serif;
+  font-size: 15px;
+  font-weight: 500;
+  text-decoration: none;
+  justify-content: center;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.3);
+  transition: all 0.2s;
+  margin-top: 8px;
+}
+
+.googleBtn:hover {
+  background: #f8f8f8;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.4);
+  transform: translateY(-1px);
+}
+
+.googleIcon {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+}

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -9,6 +9,7 @@ export default mergeConfig(
       setupFiles: ["./src/test/setup.ts"],
       globals: true,
       css: true,
+      exclude: ["**/node_modules/**", "**/e2e/**"],
     },
   })
 );

--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -1,12 +1,30 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createHmac } from "node:crypto";
 import app from "./index";
+
+const TEST_JWT_SECRET = "test-secret-for-unit-tests";
 
 const ENV = {
   ASANA_TOKEN: "fake-token",
   ASANA_PROJECT_ID: "fake-project-id",
+  GOOGLE_CLIENT_ID: "fake-client-id",
+  GOOGLE_CLIENT_SECRET: "fake-client-secret",
+  JWT_SECRET: TEST_JWT_SECRET,
+  ALLOWED_EMAIL: "test@example.com",
+  FRONTEND_URL: "http://localhost:5173",
 };
 
 // ── ヘルパー ──────────────────────────────────────────────
+
+/** テスト用 JWT トークンを Node crypto で生成（Web Crypto と HMAC-SHA256 互換）*/
+function createTestToken(secret = TEST_JWT_SECRET): string {
+  const header = Buffer.from(JSON.stringify({ alg: "HS256", typ: "JWT" })).toString("base64url");
+  const payload = Buffer.from(
+    JSON.stringify({ email: "test@example.com", name: "Test", picture: "", exp: Math.floor(Date.now() / 1000) + 3600 })
+  ).toString("base64url");
+  const sig = createHmac("sha256", secret).update(`${header}.${payload}`).digest("base64url");
+  return `${header}.${payload}.${sig}`;
+}
 
 function asanaTask(overrides: Record<string, unknown> = {}) {
   return {
@@ -28,8 +46,21 @@ function mockFetch(data: unknown, status = 200) {
   });
 }
 
+/** 認証ヘッダー付きリクエスト */
 function req(path: string, init?: RequestInit) {
-  return app.request(path, init, ENV);
+  const token = createTestToken();
+  return app.request(
+    path,
+    {
+      ...init,
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+        ...(init?.headers as Record<string, string> ?? {}),
+      },
+    },
+    ENV
+  );
 }
 
 beforeEach(() => {
@@ -109,6 +140,20 @@ describe("GET /api/todos", () => {
     const todos = await res.json();
     expect(todos).toEqual([]);
   });
+
+  it("認証ヘッダーなしは 401 を返す", async () => {
+    const res = await app.request("/api/todos", {}, ENV);
+    expect(res.status).toBe(401);
+  });
+
+  it("無効なトークンは 401 を返す", async () => {
+    const res = await app.request(
+      "/api/todos",
+      { headers: { Authorization: "Bearer invalid.token.here" } },
+      ENV
+    );
+    expect(res.status).toBe(401);
+  });
 });
 
 // ── POST /api/todos ───────────────────────────────────────
@@ -117,7 +162,6 @@ describe("POST /api/todos", () => {
     vi.stubGlobal("fetch", mockFetch({ data: asanaTask({ name: "新タスク" }) }));
     const res = await req("/api/todos", {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ title: "新タスク", memo: "メモ" }),
     });
     expect(res.status).toBe(201);
@@ -140,7 +184,6 @@ describe("POST /api/todos", () => {
     );
     await req("/api/todos", {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ title: "T", memo: "メモ本文", priority: 2 }),
     });
     expect(capturedNotes).toContain("メモ本文");
@@ -162,7 +205,6 @@ describe("POST /api/todos", () => {
     );
     await req("/api/todos", {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ title: "T" }),
     });
     expect(capturedNotes).toContain("priority:0");
@@ -180,7 +222,6 @@ describe("POST /api/todos/bulk", () => {
     );
     const res = await req("/api/todos/bulk", {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ titles: ["タスクA", "タスクB"] }),
     });
     expect(res.status).toBe(201);
@@ -206,7 +247,6 @@ describe("PATCH /api/todos/:id", () => {
 
     const res = await req("/api/todos/123", {
       method: "PATCH",
-      headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ memo: "新メモ" }),
     });
     expect(res.status).toBe(200);
@@ -233,7 +273,6 @@ describe("PATCH /api/todos/:id", () => {
     );
     await req("/api/todos/123", {
       method: "PATCH",
-      headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ memo: "新メモ" }),
     });
     expect(capturedNotes).toContain("新メモ");
@@ -263,7 +302,6 @@ describe("PATCH /api/todos/:id", () => {
     );
     await req("/api/todos/123", {
       method: "PATCH",
-      headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ snoozedUntil: null }),
     });
     expect(capturedNotes).not.toContain("snoozedUntil");
@@ -276,7 +314,6 @@ describe("PATCH /api/todos/:id/complete", () => {
     vi.stubGlobal("fetch", mockFetch({ data: asanaTask({ completed: true }) }));
     const res = await req("/api/todos/123/complete", {
       method: "PATCH",
-      headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ completed: true }),
     });
     expect(res.status).toBe(200);
@@ -288,7 +325,6 @@ describe("PATCH /api/todos/:id/complete", () => {
     vi.stubGlobal("fetch", mockFetch({ data: asanaTask({ completed: false }) }));
     const res = await req("/api/todos/123/complete", {
       method: "PATCH",
-      headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ completed: false }),
     });
     const todo = await res.json();
@@ -309,9 +345,14 @@ describe("DELETE /api/todos/:id", () => {
 
 // ── CORS ──────────────────────────────────────────────────
 describe("CORS", () => {
-  it("全ルートに Access-Control-Allow-Origin ヘッダーが付く", async () => {
+  it("Origin ヘッダーを反映した Access-Control-Allow-Origin を返す", async () => {
     vi.stubGlobal("fetch", mockFetch({ data: [] }));
-    const res = await req("/api/todos");
-    expect(res.headers.get("access-control-allow-origin")).toBe("*");
+    const token = createTestToken();
+    const res = await app.request(
+      "/api/todos",
+      { headers: { Origin: "http://localhost:5173", Authorization: `Bearer ${token}` } },
+      ENV
+    );
+    expect(res.headers.get("access-control-allow-origin")).toBe("http://localhost:5173");
   });
 });

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1,10 +1,20 @@
 import { Hono } from "hono";
 import { cors } from "hono/cors";
+import type { MiddlewareHandler } from "hono";
 
 // ── 型定義 ────────────────────────────────────────────────
 type Bindings = {
   ASANA_TOKEN: string;
-  ASANA_PROJECT_ID: string; // 1202804017257914
+  ASANA_PROJECT_ID: string;
+  GOOGLE_CLIENT_ID: string;
+  GOOGLE_CLIENT_SECRET: string;
+  JWT_SECRET: string;
+  ALLOWED_EMAIL: string;   // カンマ区切りの許可メールアドレス
+  FRONTEND_URL: string;    // e.g. http://localhost:5173
+};
+
+type Variables = {
+  user: { email: string; name: string; picture: string; exp: number };
 };
 
 type AsanaTask = {
@@ -16,7 +26,87 @@ type AsanaTask = {
   custom_fields: { gid: string; number_value: number | null }[];
 };
 
+// ── JWT ──────────────────────────────────────────────────
+
+function b64url(input: string): string {
+  const bytes = new TextEncoder().encode(input);
+  let binary = "";
+  bytes.forEach((b) => (binary += String.fromCharCode(b)));
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+}
+
+function b64urlDecode(s: string): string {
+  const r = s.replace(/-/g, "+").replace(/_/g, "/");
+  const pad = r.length % 4;
+  const padded = pad ? r + "=".repeat(4 - pad) : r;
+  const binary = atob(padded);
+  const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0));
+  return new TextDecoder().decode(bytes);
+}
+
+async function signJwt(payload: object, secret: string): Promise<string> {
+  const header = b64url(JSON.stringify({ alg: "HS256", typ: "JWT" }));
+  const body = b64url(JSON.stringify(payload));
+  const data = `${header}.${body}`;
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+  const sig = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(data));
+  const sigBinary = String.fromCharCode(...new Uint8Array(sig));
+  return `${data}.${btoa(sigBinary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "")}`;
+}
+
+async function verifyJwt(
+  token: string,
+  secret: string
+): Promise<Record<string, unknown> | null> {
+  const parts = token.split(".");
+  if (parts.length !== 3) return null;
+  const [header, body, sig] = parts;
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["verify"]
+  );
+  const r = sig.replace(/-/g, "+").replace(/_/g, "/");
+  const pad = r.length % 4;
+  const sigBytes = Uint8Array.from(atob(pad ? r + "=".repeat(4 - pad) : r), (c) =>
+    c.charCodeAt(0)
+  );
+  const valid = await crypto.subtle.verify(
+    "HMAC",
+    key,
+    sigBytes,
+    new TextEncoder().encode(`${header}.${body}`)
+  );
+  if (!valid) return null;
+  const payload = JSON.parse(b64urlDecode(body)) as Record<string, unknown>;
+  if (typeof payload.exp === "number" && payload.exp < Date.now() / 1000) return null;
+  return payload;
+}
+
+// ── 認証ミドルウェア ──────────────────────────────────────
+
+const authMiddleware: MiddlewareHandler<{ Bindings: Bindings; Variables: Variables }> = async (
+  c,
+  next
+) => {
+  const auth = c.req.header("Authorization");
+  if (!auth?.startsWith("Bearer ")) return c.json({ error: "Unauthorized" }, 401);
+  const payload = await verifyJwt(auth.slice(7), c.env.JWT_SECRET);
+  if (!payload) return c.json({ error: "Unauthorized" }, 401);
+  c.set("user", payload as Variables["user"]);
+  await next();
+};
+
 // ── Asana API ヘルパー ────────────────────────────────────
+
 function asanaFetch(token: string, path: string, options: RequestInit = {}) {
   return fetch(`https://app.asana.com/api/1.0${path}`, {
     ...options,
@@ -31,16 +121,12 @@ function asanaFetch(token: string, path: string, options: RequestInit = {}) {
 // Asana タスク → アプリ形式に変換
 function toTodo(task: AsanaTask) {
   const notes = task.notes ?? "";
-
-  // notes の1行目をメモ、残りをメタデータとして扱う
-  // フォーマット: メモ本文\n---\npriority:N\nsnoozedUntil:YYYY-MM-DD
   const [memoRaw, metaRaw] = notes.split("\n---\n");
   const meta: Record<string, string> = {};
   (metaRaw ?? "").split("\n").forEach((line) => {
     const [k, v] = line.split(":");
     if (k && v) meta[k.trim()] = v.trim();
   });
-
   return {
     id: task.gid,
     title: task.name,
@@ -61,9 +147,108 @@ function toNotes(memo: string, priority: number, snoozedUntil: string | null) {
 }
 
 // ── Hono アプリ ───────────────────────────────────────────
-const app = new Hono<{ Bindings: Bindings }>();
 
-app.use("*", cors());
+const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
+
+app.use(
+  "*",
+  cors({
+    origin: (origin) => origin ?? "*",
+    allowHeaders: ["Authorization", "Content-Type"],
+    allowMethods: ["GET", "POST", "PATCH", "DELETE", "OPTIONS"],
+    credentials: true,
+  })
+);
+
+// ── 認証ルート ────────────────────────────────────────────
+
+// Google OAuth 開始
+app.get("/auth/google", (c) => {
+  const callbackUrl = `${new URL(c.req.url).origin}/auth/callback`;
+  const params = new URLSearchParams({
+    client_id: c.env.GOOGLE_CLIENT_ID,
+    redirect_uri: callbackUrl,
+    response_type: "code",
+    scope: "openid email profile",
+    access_type: "offline",
+    prompt: "select_account",
+  });
+  return c.redirect(`https://accounts.google.com/o/oauth2/v2/auth?${params}`);
+});
+
+// Google OAuth コールバック
+app.get("/auth/callback", async (c) => {
+  const code = c.req.query("code");
+  const error = c.req.query("error");
+  const callbackUrl = `${new URL(c.req.url).origin}/auth/callback`;
+
+  if (error || !code) {
+    return c.redirect(`${c.env.FRONTEND_URL}?auth_error=cancelled`);
+  }
+
+  // 認可コード → アクセストークン交換
+  const tokenRes = await fetch("https://oauth2.googleapis.com/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      code,
+      client_id: c.env.GOOGLE_CLIENT_ID,
+      client_secret: c.env.GOOGLE_CLIENT_SECRET,
+      redirect_uri: callbackUrl,
+      grant_type: "authorization_code",
+    }),
+  });
+
+  if (!tokenRes.ok) {
+    return c.redirect(`${c.env.FRONTEND_URL}?auth_error=token_exchange`);
+  }
+
+  const { id_token } = await tokenRes.json<{ id_token: string }>();
+
+  // Google の ID トークンからユーザー情報を取得
+  const [, payloadB64] = id_token.split(".");
+  const claims = JSON.parse(b64urlDecode(payloadB64)) as {
+    email: string;
+    name: string;
+    picture: string;
+    email_verified: boolean;
+  };
+
+  if (!claims.email_verified) {
+    return c.redirect(`${c.env.FRONTEND_URL}?auth_error=unverified`);
+  }
+
+  // 許可リストチェック
+  const allowed = c.env.ALLOWED_EMAIL.split(",").map((e) => e.trim().toLowerCase());
+  if (!allowed.includes(claims.email.toLowerCase())) {
+    return c.redirect(`${c.env.FRONTEND_URL}?auth_error=unauthorized`);
+  }
+
+  // JWT 発行（有効期限 7 日）
+  const jwt = await signJwt(
+    {
+      email: claims.email,
+      name: claims.name,
+      picture: claims.picture,
+      exp: Math.floor(Date.now() / 1000) + 7 * 24 * 60 * 60,
+    },
+    c.env.JWT_SECRET
+  );
+
+  return c.redirect(`${c.env.FRONTEND_URL}?token=${jwt}`);
+});
+
+// ログイン中ユーザー情報
+app.get("/auth/me", async (c) => {
+  const auth = c.req.header("Authorization");
+  if (!auth?.startsWith("Bearer ")) return c.json({ user: null });
+  const payload = await verifyJwt(auth.slice(7), c.env.JWT_SECRET);
+  return c.json({ user: payload ?? null });
+});
+
+// ── API ルート（要認証）──────────────────────────────────
+
+app.use("/api/*", authMiddleware);
 
 // GET /api/todos — タスク一覧取得
 app.get("/api/todos", async (c) => {
@@ -124,7 +309,6 @@ app.patch("/api/todos/:id", async (c) => {
     snoozedUntil?: string | null;
   }>();
 
-  // 現在の notes を取得してマージ
   const current = await asanaFetch(
     c.env.ASANA_TOKEN,
     `/tasks/${id}?opt_fields=gid,name,notes,completed,due_on`

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -3,5 +3,12 @@ main = "src/index.ts"
 compatibility_date = "2024-01-01"
 
 [vars]
-# 本番は wrangler secret put ASANA_TOKEN で設定
 ASANA_PROJECT_ID = "1202804017257914"
+GOOGLE_CLIENT_ID = ""     # Google Cloud Console で取得した OAuth クライアント ID
+ALLOWED_EMAIL    = ""     # 許可するメールアドレス（カンマ区切り）例: "you@gmail.com"
+FRONTEND_URL     = "http://localhost:5173"  # 本番は Cloudflare Pages の URL に更新
+
+# 以下はシークレットとして設定すること:
+#   wrangler secret put ASANA_TOKEN
+#   wrangler secret put GOOGLE_CLIENT_SECRET
+#   wrangler secret put JWT_SECRET


### PR DESCRIPTION
## 概要

このセッションで実施した全変更をまとめてマージします。

## 変更内容

- **CLAUDE.md** — コードベースの包括的ドキュメントを整備
- **CSS Modules 移行** — インラインスタイルを `*.module.css` に移行、コンポーネント分割
- **設定ファイル更新** — devcontainer / tsconfig / vitest.config を最新構成に対応
- **Vitest ユニットテスト** — Worker (22件) + Frontend (71件) 計93件
- **Playwright E2E テスト** — 42件（stack / actions / add / list-view）
- **Google OAuth 認証** — Worker に JWT ベース認証、LoginScreen コンポーネント
- **pre-push フック** — push 前に全テストを実行してブロック
- **GitHub Actions CI** — push/PR 時にユニットテストと E2E テストを自動実行